### PR TITLE
Initial setup for 1.8 backport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,3 +7,4 @@
 - Fixed errors on joining spectator
 - Fixed errors on leaving
 - Fixed heading not working on parkour
+- Initial 1.8.8 backport setup

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Welcome to the Infinite Parkour repo.
 
 To use this project, you can use **[Jitpack](https://jitpack.io/#efnilite/walk-in-the-park)** to get the source and include it in your preferred build method.
 
+### Building
+
+The `1.8-backport` branch targets **Java 8** and Spigot **1.8.8**. Ensure your JDK is 8u202 or higher when compiling.
+

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>5.3.1</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.8.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -118,6 +118,26 @@
             <artifactId>placeholderapi</artifactId>
             <version>2.11.2</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.cryptomorin</groupId>
+            <artifactId>XSeries</artifactId>
+            <version>9.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>item-nbt-api</artifactId>
+            <version>2.12.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>5.1.0</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,6 @@ name: 'IP'
 description: 'Infinitely automatically generating parkour plugin.'
 author: Efnilite
 version: 5.3.1
-api-version: 1.16
 main: dev.efnilite.ip.IP
 softdepend: [floodgate, Vault, PlaceholderAPI, Multiverse-Core, VoidGen]
 commands:


### PR DESCRIPTION
## Summary
- start `1.8-backport` branch
- set Maven compiler target to Java 8 and use Spigot 1.8.8 API
- add XSeries, ItemNBTAPI and ProtocolLib dependencies
- remove api-version from `plugin.yml`
- document Java 8 build target
- note backport in changelog

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684a6185ca7c83319ddcdcd77a193291