### PR TITLE
Implement cross-version utilities and add NBT usage

### DIFF
--- a/src/main/java/dev/efnilite/ip/config/Locales.java
+++ b/src/main/java/dev/efnilite/ip/config/Locales.java
@@ -5,6 +5,7 @@ import dev.efnilite.ip.menu.ParkourOption;
 import dev.efnilite.ip.player.ParkourUser;
 import dev.efnilite.vilib.inventory.item.Item;
 import dev.efnilite.vilib.util.Task;
+import dev.efnilite.ip.util.MaterialAdapter;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -236,7 +237,7 @@ public class Locales {
             idx++;
         }
 
-        Item item = new Item(Material.getMaterial(material.toUpperCase()), name);
+        Item item = new Item(MaterialAdapter.adapt(material), name);
 
         if (!lore.isEmpty()) {
             item.lore(lore.split("\\|\\|"));

--- a/src/main/java/dev/efnilite/ip/config/Option.java
+++ b/src/main/java/dev/efnilite/ip/config/Option.java
@@ -6,6 +6,9 @@ import dev.efnilite.ip.menu.ParkourOption;
 import dev.efnilite.ip.style.RandomStyle;
 import dev.efnilite.ip.style.Style;
 import dev.efnilite.vilib.particle.ParticleData;
+import dev.efnilite.ip.util.MaterialAdapter;
+import dev.efnilite.ip.util.ParticleAdapter;
+import dev.efnilite.ip.util.SoundAdapter;
 import org.bukkit.*;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -136,22 +139,11 @@ public class Option {
     public static ParticleData<?> PARTICLE_DATA;
 
     private static void initEnums() {
-        String value = Config.CONFIG.getString("particles.sound-type").toUpperCase();
-
-        try {
-            SOUND_TYPE = Sound.valueOf(value);
-        } catch (IllegalArgumentException ex) {
-            SOUND_TYPE = Sound.valueOf("BLOCK_NOTE_PLING");
-            IP.logging().error("Invalid sound: %s".formatted(value));
-        }
+        String value = Config.CONFIG.getString("particles.sound-type");
+        SOUND_TYPE = SoundAdapter.adapt(value);
 
         value = Config.CONFIG.getString("particles.particle-type");
-        try {
-            PARTICLE_TYPE = Particle.valueOf(value);
-        } catch (IllegalArgumentException ex) {
-            PARTICLE_TYPE = Particle.valueOf("SPELL_INSTANT");
-            IP.logging().error("Invalid particle type: %s".formatted(value));
-        }
+        PARTICLE_TYPE = ParticleAdapter.adapt(value);
 
         SOUND_PITCH = Config.CONFIG.getInt("particles.sound-pitch");
         SOUND_VOLUME = Config.CONFIG.getInt("particles.sound-volume");
@@ -247,13 +239,11 @@ public class Option {
             styles.add(fn.apply(style,
                     config.getStringList("%s.%s".formatted(path, style)).stream()
                             .map(name -> {
-                                var material = Material.getMaterial(name.toUpperCase());
-
+                                Material material = MaterialAdapter.adapt(name);
                                 if (material == null) {
                                     IP.logging().error("Invalid material %s in style %s".formatted(name, style));
                                     return Material.STONE;
                                 }
-
                                 return material;
                             })
                             .toList()));

--- a/src/main/java/dev/efnilite/ip/generator/Island.java
+++ b/src/main/java/dev/efnilite/ip/generator/Island.java
@@ -6,6 +6,7 @@ import dev.efnilite.ip.session.Session;
 import dev.efnilite.vilib.schematic.Schematic;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import dev.efnilite.ip.util.MaterialAdapter;
 import org.bukkit.block.Block;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -51,8 +52,8 @@ public final class Island {
 
         blocks = schematic.paste(location.subtract(0, schematic.getDimensions().getY(), 0));
 
-        Material playerMaterial = Material.getMaterial(Config.GENERATION.getString("advanced.island.spawn.player-block").toUpperCase());
-        Material parkourMaterial = Material.getMaterial(Config.GENERATION.getString("advanced.island.parkour.begin-block").toUpperCase());
+        Material playerMaterial = MaterialAdapter.adapt(Config.GENERATION.getString("advanced.island.spawn.player-block"));
+        Material parkourMaterial = MaterialAdapter.adapt(Config.GENERATION.getString("advanced.island.parkour.begin-block"));
 
         try {
             Block player = blocks.stream().filter(block -> block.getType() == playerMaterial).findAny().orElseThrow();

--- a/src/main/java/dev/efnilite/ip/menu/community/SingleLeaderboardMenu.java
+++ b/src/main/java/dev/efnilite/ip/menu/community/SingleLeaderboardMenu.java
@@ -20,6 +20,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
+import de.tr7zw.changeme.nbtapi.NBTItem;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,6 +72,10 @@ public class SingleLeaderboardMenu {
 
             // Player head gathering
             ItemStack stack = item.build();
+            NBTItem nbt = new NBTItem(stack);
+            nbt.setString("ip-player", uuid.toString());
+            stack = nbt.getItem();
+            item.stack(stack);
 
             // if there are more than 36 players, don't show the heads to avoid server crashing
             // and bedrock has no player skull support

--- a/src/main/java/dev/efnilite/ip/player/ParkourSpectator.java
+++ b/src/main/java/dev/efnilite/ip/player/ParkourSpectator.java
@@ -7,8 +7,7 @@ import dev.efnilite.ip.player.data.PreviousData;
 import dev.efnilite.ip.session.Session;
 import dev.efnilite.vilib.util.Strings;
 import dev.efnilite.vilib.util.Task;
-import net.md_5.bungee.api.ChatMessageType;
-import net.md_5.bungee.api.chat.TextComponent;
+import dev.efnilite.ip.util.MessageUtil;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
@@ -75,7 +74,7 @@ public class ParkourSpectator extends ParkourUser {
      * Updates the spectator's action bar, scoreboard and checks distance.
      */
     public void update() {
-        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(Strings.colour(Locales.getString(player, "play.spectator.action_bar"))));
+        MessageUtil.sendActionBar(player, Strings.colour(Locales.getString(player, "play.spectator.action_bar")));
         player.setGameMode(GameMode.SPECTATOR);
         updateScoreboard(session.generator);
 

--- a/src/main/java/dev/efnilite/ip/player/ParkourUser.java
+++ b/src/main/java/dev/efnilite/ip/player/ParkourUser.java
@@ -21,6 +21,8 @@ import dev.efnilite.ip.storage.Storage;
 import dev.efnilite.ip.world.Divider;
 import dev.efnilite.vilib.fastboard.FastBoard;
 import dev.efnilite.vilib.util.Strings;
+import dev.efnilite.ip.util.ScoreboardUtil;
+import org.bukkit.scoreboard.Team;
 import io.papermc.lib.PaperLib;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
@@ -231,6 +233,15 @@ public abstract class ParkourUser {
 
         if (Boolean.parseBoolean(Option.OPTIONS_DEFAULTS.get(ParkourOption.SCOREBOARD))) {
             this.board = new FastBoard(player);
+
+            var scoreboard = player.getScoreboard();
+            Team team = scoreboard.getTeam("parkour");
+            if (team == null) {
+                team = scoreboard.registerNewTeam("parkour");
+            }
+            ScoreboardUtil.setCollisionRule(team, Team.OptionStatus.NEVER);
+            team.addEntry(player.getName());
+            player.setScoreboard(scoreboard);
         }
     }
 

--- a/src/main/java/dev/efnilite/ip/util/MaterialAdapter.java
+++ b/src/main/java/dev/efnilite/ip/util/MaterialAdapter.java
@@ -1,0 +1,15 @@
+package dev.efnilite.ip.util;
+
+import com.cryptomorin.xseries.XMaterial;
+import org.bukkit.Material;
+
+import java.util.Optional;
+
+public final class MaterialAdapter {
+    private MaterialAdapter() {}
+
+    public static Material adapt(String name) {
+        Optional<XMaterial> xMat = XMaterial.matchXMaterial(name);
+        return xMat.map(XMaterial::parseMaterial).orElse(Material.STONE);
+    }
+}

--- a/src/main/java/dev/efnilite/ip/util/MessageUtil.java
+++ b/src/main/java/dev/efnilite/ip/util/MessageUtil.java
@@ -1,0 +1,45 @@
+package dev.efnilite.ip.util;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Utility methods for sending titles and action bars across versions.
+ */
+public final class MessageUtil {
+    private MessageUtil() {}
+
+    public static void sendTitle(Player player, String title, String sub, int fadeIn, int stay, int fadeOut) {
+        try {
+            player.sendTitle(title, sub, fadeIn, stay, fadeOut);
+        } catch (NoSuchMethodError ignored) {
+            // Title API not available
+        }
+    }
+
+    public static void sendActionBar(Player player, String message) {
+        try {
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));
+        } catch (NoSuchMethodError ex) {
+            sendPacket(player, message);
+        }
+    }
+
+    private static void sendPacket(Player player, String message) {
+        try {
+            String version = Bukkit.getServer().getClass().getPackage().getName().split(".")[3];
+            Class<?> chatBaseComponent = Class.forName("net.minecraft.server." + version + ".IChatBaseComponent");
+            Class<?> serializer = Class.forName(chatBaseComponent.getName() + "$ChatSerializer");
+            Object comp = serializer.getMethod("a", String.class).invoke(null, "{\"text\":\"" + message.replace("\"", "\\\"") + "\"}");
+            Class<?> packetClass = Class.forName("net.minecraft.server." + version + ".PacketPlayOutChat");
+            Object packet = packetClass.getConstructor(chatBaseComponent, byte.class).newInstance(comp, (byte) 2);
+            Object craft = player.getClass().getMethod("getHandle").invoke(player);
+            Object connection = craft.getClass().getField("playerConnection").get(craft);
+            connection.getClass().getMethod("sendPacket", Class.forName("net.minecraft.server." + version + ".Packet")).invoke(connection, packet);
+        } catch (Throwable ignored) {
+            // ignore
+        }
+    }
+}

--- a/src/main/java/dev/efnilite/ip/util/ParticleAdapter.java
+++ b/src/main/java/dev/efnilite/ip/util/ParticleAdapter.java
@@ -1,0 +1,13 @@
+package dev.efnilite.ip.util;
+
+import com.cryptomorin.xseries.particles.XParticle;
+import org.bukkit.Particle;
+
+public final class ParticleAdapter {
+    private ParticleAdapter() {}
+
+    public static Particle adapt(String name) {
+        Particle particle = XParticle.getParticle(name);
+        return particle != null ? particle : Particle.FLAME;
+    }
+}

--- a/src/main/java/dev/efnilite/ip/util/ScoreboardUtil.java
+++ b/src/main/java/dev/efnilite/ip/util/ScoreboardUtil.java
@@ -1,0 +1,19 @@
+package dev.efnilite.ip.util;
+
+import org.bukkit.scoreboard.Team;
+
+public final class ScoreboardUtil {
+    private ScoreboardUtil() {}
+
+    public static void setCollisionRule(Team team, Team.OptionStatus status) {
+        try {
+            team.setOption(Team.Option.COLLISION_RULE, status);
+        } catch (NoSuchMethodError ignored) {
+            // 1.8 does not support collision rule
+        }
+    }
+
+    public static String truncate(String name) {
+        return name.length() > 16 ? name.substring(0, 16) : name;
+    }
+}

--- a/src/main/java/dev/efnilite/ip/util/SoundAdapter.java
+++ b/src/main/java/dev/efnilite/ip/util/SoundAdapter.java
@@ -1,0 +1,14 @@
+package dev.efnilite.ip.util;
+
+import com.cryptomorin.xseries.XSound;
+import org.bukkit.Sound;
+
+public final class SoundAdapter {
+    private SoundAdapter() {}
+
+    public static Sound adapt(String name) {
+        return XSound.matchXSound(name)
+                .map(XSound::parseSound)
+                .orElse(XSound.BLOCK_NOTE_BLOCK_PLING.parseSound());
+    }
+}

--- a/src/main/java/dev/efnilite/ip/world/VoidChunkGenerator1_8.java
+++ b/src/main/java/dev/efnilite/ip/world/VoidChunkGenerator1_8.java
@@ -1,0 +1,30 @@
+package dev.efnilite.ip.world;
+
+import org.bukkit.World;
+import org.bukkit.block.Biome;
+import org.bukkit.generator.BlockPopulator;
+import org.bukkit.generator.ChunkGenerator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Simple void generator for 1.8 servers.
+ */
+public class VoidChunkGenerator1_8 extends ChunkGenerator {
+    @Override
+    public List<BlockPopulator> getDefaultPopulators(World world) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public byte[][] generateBlockSections(World world, Random random, int x, int z, BiomeGrid biomes) {
+        for (int cx = 0; cx < 16; cx++) {
+            for (int cz = 0; cz < 16; cz++) {
+                biomes.setBiome(cx, cz, Biome.PLAINS);
+            }
+        }
+        return new byte[world.getMaxHeight() / 16][];
+    }
+}

--- a/src/main/java/dev/efnilite/ip/world/World.java
+++ b/src/main/java/dev/efnilite/ip/world/World.java
@@ -2,7 +2,8 @@ package dev.efnilite.ip.world;
 
 import dev.efnilite.ip.IP;
 import dev.efnilite.ip.config.Config;
-import dev.efnilite.vilib.util.VoidGenerator;
+import dev.efnilite.ip.config.Option;
+import dev.efnilite.ip.world.VoidChunkGenerator1_8;
 import org.bukkit.*;
 
 import java.io.File;
@@ -47,8 +48,14 @@ public class World {
             WorldCreator creator = new WorldCreator(name)
                     .generateStructures(false)
                     .type(WorldType.NORMAL)
-                    .generator(VoidGenerator.getGenerator()) // to fix No keys in MapLayer etc.
                     .environment(org.bukkit.World.Environment.NORMAL);
+
+            var vg = Bukkit.getPluginManager().getPlugin("VoidGen");
+            if (vg != null) {
+                creator.generator(vg.getDefaultWorldGenerator(name, null));
+            } else {
+                creator.generator(new VoidChunkGenerator1_8());
+            }
 
             world = Bukkit.createWorld(creator);
         } catch (Exception ex) {
@@ -69,7 +76,7 @@ public class World {
         world.setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);
 
         world.getWorldBorder().setCenter(0, 0);
-        world.getWorldBorder().setSize(10_000_000);
+        world.getWorldBorder().setSize(Option.BORDER_SIZE);
         world.setDifficulty(Difficulty.PEACEFUL);
         world.setClearWeatherDuration(1000000);
         world.setAutoSave(false);

--- a/src/main/resources/locales/en.yml
+++ b/src/main/resources/locales/en.yml
@@ -34,7 +34,7 @@ play:
     name: "<white>Spectator"
 
     join: "<#4CB3FF>You are now a spectator. You can use \"/parkour\" to leave/change your gamemode."
-    action_bar: "<#4CB3FF>You are a spectator <gray>• <#4CB3FF>Use \"/parkour\" to leave."
+    action_bar: "<#4CB3FF>Right-click a player to spectate <gray>• <#4CB3FF>Use \"/parkour\" to leave."
 
     other_join: "<dark_green><bold>+ <reset><gray>%s started spectating you"
     other_leave: "<red><bold>- <reset><gray>%s stopped spectating you"


### PR DESCRIPTION
## Summary
- add adapters for materials, sounds, particles
- add MessageUtil for titles and action bars
- add ScoreboardUtil helper
- use adapters in config parsing and island generation
- store leaderboard player UUID in item NBT
- update spectator to use MessageUtil
- implement 1.8 void chunk generator and detect VoidGen
- set world border size from config
- disable collisions via scoreboard team
- tweak spectator action bar message

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684a636d155c8331a68c07b8f606e9ed